### PR TITLE
Revert "adds continuous integration research"

### DIFF
--- a/week5/ContinuousIntegration.md
+++ b/week5/ContinuousIntegration.md
@@ -1,1 +1,0 @@
-[Here](https://hackmd.io/vj9FRHykQ1y68Nfk0l3PWQ) is the HackMD file for our research on Continuous Integration/Travis.


### PR DESCRIPTION
Reverts fac-13/research#20

Hi tspeed90. 

Perhaps best to copy/past all the markdown from the link direct into gitHub rather than use the HackMD link? 

Also, I believe we need to add the link to week5 folder research the main repo README.md

😺 